### PR TITLE
Remove inexistent rule

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -21,7 +21,6 @@
     "react/jsx-indent-props": [2, 2],
     "react/jsx-no-duplicate-props": 2,
     "react/jsx-no-undef": 2,
-    "react/jsx-space-before-closing": 2,
     "react/jsx-uses-react": 2,
     "react/jsx-uses-vars": 2,
     "react/self-closing-comp": 2


### PR DESCRIPTION
`10:1   error  Definition for rule 'react/jsx-space-before-closing' was not found`
